### PR TITLE
releng: don't redefine plugins defined in parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,32 +40,19 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <!-- necessary for reproducible builds, automatically updated with each release -->
+        <project.build.outputTimestamp>2020-07-02T15:10:15Z</project.build.outputTimestamp>
     </properties>
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>biz.aQute.bnd</groupId>
-                <artifactId>bnd-maven-plugin</artifactId>
-            </plugin>
+            
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
                 <configuration>
                     <failOnMissing>false</failOnMissing>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.sling</groupId>
-                <artifactId>sling-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.rat</groupId>
@@ -101,11 +88,6 @@
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.util.function</artifactId>
                 <version>1.1.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.osgi</groupId>
-                <artifactId>org.osgi.util.tracker</artifactId>
-                <version>1.5.1</version>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>

--- a/src/test/java/org/apache/sling/sitemap/impl/builder/SitemapImplTest.java
+++ b/src/test/java/org/apache/sling/sitemap/impl/builder/SitemapImplTest.java
@@ -119,7 +119,7 @@ class SitemapImplTest extends AbstractBuilderTest {
         // given
         Writer throwingWriter = new Writer() {
             @Override
-            public void write(@NotNull char[] cbuf, int off, int len) throws IOException {
+            public void write(char[] cbuf, int off, int len) throws IOException {
                 throw new IOException();
             }
 


### PR DESCRIPTION
add output timestamp property for reproducible builds