### PR TITLE
SLING-12440 - Change Extension annotation from ProviderType to ConsumerType

### DIFF
--- a/src/main/java/org/apache/sling/sitemap/builder/Extension.java
+++ b/src/main/java/org/apache/sling/sitemap/builder/Extension.java
@@ -18,7 +18,7 @@
  */
 package org.apache.sling.sitemap.builder;
 
-import org.osgi.annotation.versioning.ProviderType;
+import org.osgi.annotation.versioning.ConsumerType;
 
 /**
  * A marker interface used as consumer facing API for custom extensions.
@@ -26,6 +26,6 @@ import org.osgi.annotation.versioning.ProviderType;
  * Implementations must extend this interface to provide a sub type of it that can be added to a {@link Url} using
  * {@link Url#addExtension(Class)}.
  */
-@ProviderType
+@ConsumerType
 public interface Extension {
 }

--- a/src/main/java/org/apache/sling/sitemap/builder/package-info.java
+++ b/src/main/java/org/apache/sling/sitemap/builder/package-info.java
@@ -20,7 +20,7 @@
 /**
  * This package provide a builder-like API to create XML sitemaps.
  */
-@Version("1.0.0")
+@Version("1.1.0")
 package org.apache.sling.sitemap.builder;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
This PR allows to `extends` the `org.apache.sling.sitemap.builder.Extension` interface, which is necessary for adding [custom Sitemap Extensions](https://github.com/apache/sling-org-apache-sling-sitemap?tab=readme-ov-file#sitemap-extensions). More details can be found here: [SLING-12440](https://issues.apache.org/jira/browse/SLING-12440) 